### PR TITLE
Support .toml extension for theme files and fix configuration directory behaviour

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,22 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-> **Note:** The frequency spectrum visualization may appear noisy in this release. This will be improved in a future version once [ratatui#2426](https://github.com/ratatui/ratatui/pull/2426) is merged, which adds a filled-area chart rendering mode that will fill the area under the curve.
+> **Note:** The frequency spectrum visualization may appear noisy. This will be improved in a future versions once ratatui v0.30.1 releases, which adds a filled-area chart rendering mode that will fill the area under the curve.
 
 ---
-## [1.9.0] - 2026-03-22
+## [1.9.1] - 2026-05-05
 
 ### Features
 - **Added** dBFS (decibels relative to full scale) scaling for accurate spectrum visualization.
 - **Added** pink noise compensation (+3 dB/octave) to make pink noise appear flat on the logarithmic frequency scale.
 - **Added** FFT normalization so that songs with lower loudness don't appear at the bottom of the chart.
+- **Added** support for `.toml` theme files. Using `.toml` instead of the custom `.theme` extension enables syntax highlighting in editors, since the format was always TOML under the hood. It is recommended to rename existing `.theme` files to `.toml`, although `.theme` files are still supported for backwards compatibility.
 
 ### Fixes
 - **Fixed** custom theme selection issue.
+- **Fixed** config directory and `.current_theme` file being created on startup even when the user hasn't changed the theme from default. Now they are only created once the user actually switches to a non-default theme ([#64](https://github.com/bananaofhappiness/soundscope/issues/64)).
 
 ### Changes
 - **Updated** TUI Y-axis bounds to display the new 0 to -100 dB range.
 
 ### Known Issues
 - Rapidly seeking through an audio file may cause lag, resulting in the playhead being in an incorrect position. Pausing playback and waiting for the playhead to return to the correct spot before resuming usually resolves the issue.
-- In some audio file formats, the playhead may gradually drift slightly to the right of the waveform center over time.
+- In some audio files the playhead may gradually drift slightly to the right of the waveform center over time.
+- Some files with high sample rate play back normally, but real-time visualization (waveform, spectrum, LUFS) lags significantly behind. For example, this occurs with `.wav` files with a sample rate > 48000, while `.mp3` files at 92000 play without noticeable lag.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Soundscope comes with several pre-built themes that you can use directly without
 Press `t` in the application to open the theme selection list and choose any of these built-in themes.
 
 ### Creating a custom theme
-The theme is set in `.theme` file which must be placed in `{YOUR_CONFIG_DIRECTORY}/soundscope` directory. Under the hood it is a simple `.toml` file. Here is an example theme (which is default for the app) containing all possible variables:
+The theme is set in `.toml` file which must be placed in `{YOUR_CONFIG_DIRECTORY}/soundscope` directory. Here is an example theme (which is default for the app) containing all possible variables:
 ```toml
 [global]
 background = "Black"
@@ -72,7 +72,7 @@ foreground = "221" # It is an ANSI-256 value for LightGoldenrod2 color. See http
 # that pressing L will open the LUFS meter
 highlight = "160" # Red3 color. Note that it can also be written as "#d70000"
 
-# For simplicity yellow color in this example is written as "Yellow" instead of "221", and light red is written as "LightRed" instead of "160". But default color scheme uses LightGoldenrod2 for foreground and Red3 for highlight.
+# For simplicity yellow color in this example is written as "Yellow" instead of "221", and light red is written as "LightRed" instead of "160". But default color scheme uses LightGoldenrod2 (221) for foreground and Red3 (160) for highlight.
 [waveform]
 borders = "Yellow"
 waveform = "Yellow"
@@ -160,7 +160,7 @@ Only global foreground and global background colors are mandatory. You can pass 
 
 Color separators `-`, `_`, and ` ` are supported and names are case insensitive. For example, `Light-blue` or `light_blue` or `light Blue` are all valid.
 
-After saving your theme into `.theme` file and placing it into `{YOUR_CONFIG_DIRECTORY}/soundscope`, press `t` to open up the theme selection list and choose yours.
+After saving your theme into `.toml` file and placing it into `{YOUR_CONFIG_DIRECTORY}/soundscope`, press `t` to open up the theme selection list and choose yours.
 
 ---
 ## 🐛 Known Issues
@@ -169,7 +169,8 @@ After saving your theme into `.theme` file and placing it into `{YOUR_CONFIG_DIR
 
 Other known issues:
 - Rapidly seeking through an audio file may cause lag, resulting in the playhead being in an incorrect position. Pausing playback and waiting for the playhead to return to the correct spot before resuming usually resolves the issue.
-- In some audio file formats, the playhead may gradually drift slightly to the right of the waveform center over time.
+- In some audio files the playhead may gradually drift slightly to the right of the waveform center over time.
+- Some files with high sample rate play back normally, but real-time visualization (waveform, spectrum, LUFS) lags significantly behind. For example, this occurs with `.wav` files with a sample rate > 48000, while `.mp3` files at 92000 play without noticeable lag.
 
 ---
 ## 🤝 Contributing

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -25,10 +25,11 @@ use ratatui_explorer::{FileExplorer, FileExplorerBuilder};
 use ringbuffer::{AllocRingBuffer, RingBuffer};
 use rodio::Source;
 use serde::Deserialize;
+use std::path::Path;
 use std::{
     fmt::Display,
     fs::{self, File},
-    io::{Read, Write},
+    io::Read,
     path::PathBuf,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
@@ -37,13 +38,13 @@ use std::{
 pub type RBuffer = Arc<Mutex<AllocRingBuffer<f32>>>;
 
 /// Files with extensions listed here will be shown in the explorer
-const SUPPORTED_FORMATS: [&str; 21] = [
+const SUPPORTED_FORMATS: [&str; 22] = [
     "wav", "wave", "aiff", "aif", "flac", // Uncompressed / Lossless
     "mp3", "mp2", "mp1", "mpa", "aac", // MPEG Audio
     "m4a", "m4b", "mp4", "m4r", "m4p", // MP4 / M4A Family (AAC / ALAC)
     "ogg", "oga", "ogv", // OGG Family
-    "caf", "alac",  // Apple formats
-    "theme", // Theme file
+    "caf", "alac", // Apple formats
+    "theme", "toml", // Theme file
 ];
 
 const FFT_TARGET_LUFS: f32 = -13.0;
@@ -132,7 +133,7 @@ impl Display for Mode {
     }
 }
 
-/// Defines theme using .theme file
+/// Defines theme using .toml file
 /// Otherwise, uses default values.
 #[derive(Deserialize, Default)]
 pub struct Theme {
@@ -162,7 +163,7 @@ fn fill<T>(field: &mut Option<T>, default: T) {
 }
 
 impl Theme {
-    /// Sets `self.global.foreground` and `self.global.background` for every field that was not defined in a .theme file.
+    /// Sets `self.global.foreground` and `self.global.background` for every field that was not defined in a theme file.
     pub fn apply_global_as_default(&mut self) {
         let fg = self.global.foreground;
         let bg = self.global.background;
@@ -1242,10 +1243,18 @@ impl App {
 
     /// The main loop
     fn run(mut self, mut terminal: DefaultTerminal, startup_file: Option<PathBuf>) -> Result<()> {
-        // apply theme
-        // check if config directory exists
-        if let Some(path) = config_dir() {
-            self.apply_current_theme(path);
+        // apply current theme if current_theme file exists
+        // if it doesn't, don't create a config dir, as it used to be before.
+        if let Some(mut path) = config_dir() {
+            path.push("soundscope");
+            let current_theme_file = path.join("current_theme");
+            if current_theme_file.exists() {
+                self.apply_current_theme(&path, &current_theme_file);
+            } else {
+                let mut theme = Theme::default();
+                theme.apply_global_as_default();
+                self.set_theme(theme);
+            }
         } else {
             self.handle_error("Config directory does not exist. Could not load theme.".to_string());
             let mut theme = Theme::default();
@@ -1565,7 +1574,9 @@ impl App {
                 let file = self.explorer.current();
                 let file_path = self.explorer.current().path.clone();
                 if file.is_file() {
-                    if file_path.extension().unwrap() == "theme" {
+                    if file_path.extension().unwrap() == "theme"
+                        || file_path.extension().unwrap() == "toml"
+                    {
                         self.apply_theme_file(&file_path);
                     } else {
                         self.select_audio_file(file_path);
@@ -1819,15 +1830,16 @@ impl App {
             theme.apply_global_as_default();
             self.set_theme(theme);
 
-            // Save theme choice to .current_theme file
+            // Save theme choice to current_theme file
             if let Some(mut config_path) = config_dir() {
                 config_path.push("soundscope");
-                if let Err(_err) = std::fs::create_dir_all(&config_path) {
-                    self.handle_error(
-                        "Error creating a config path. Make sure it exists.".to_owned(),
-                    );
+                if let Err(err) = fs::create_dir_all(&config_path) {
+                    self.handle_error(format!(
+                        "Error saving a theme. Make sure ~/.config/soundscope exists: {err}"
+                    ));
+                    return;
                 }
-                let current_theme_file = config_path.join(".current_theme");
+                let current_theme_file = config_path.join("current_theme");
                 if let Err(err) = fs::write(&current_theme_file, "DEFAULT") {
                     self.handle_error(format!("Error saving theme choice: {err}"));
                 }
@@ -1841,6 +1853,12 @@ impl App {
         if index == themes.len() + 1 {
             // Open explorer for custom theme selection
             if let Some(config_path) = config_dir() {
+                if !config_path.join("soundscope").exists() {
+                    self.handle_error(
+                        "Config directory not found. Create ~/.config/soundscope and place {name}.toml files in it to use custom themes.".to_owned(),
+                    );
+                    return;
+                }
                 self.ui.show_explorer = true;
                 self.explorer
                     .set_cwd(config_path.join("soundscope"))
@@ -1856,10 +1874,24 @@ impl App {
             theme.apply_global_as_default();
             self.set_theme(theme);
 
-            // Save theme choice to .current_theme file
+            // Save theme choice to current_theme file
             if let Some(mut config_path) = config_dir() {
                 config_path.push("soundscope");
-                let current_theme_file = config_path.join(".current_theme");
+                if let Err(err) = fs::create_dir_all(&config_path) {
+                    self.handle_error(format!(
+                        "Error saving a theme. Make sure ~/.config/soundscope exists: {err}"
+                    ));
+                    return;
+                }
+                let current_theme_file = config_path.join("current_theme");
+                if !current_theme_file.exists()
+                    && let Err(err) = File::create(&current_theme_file)
+                {
+                    self.handle_error(format!(
+                        "Error saving a theme. Make sure ~/.config/soundscope exists: {err}"
+                    ));
+                    return;
+                }
                 // Save as "builtin:theme_name" format
                 let theme_identifier = format!("builtin:{theme_name}");
                 if let Err(err) = fs::write(&current_theme_file, &theme_identifier) {
@@ -2004,20 +2036,20 @@ impl App {
 
     fn load_theme(&mut self, path: &PathBuf) -> Option<Theme> {
         let name = path.file_name().unwrap().to_string_lossy().to_string();
-        let current_theme = config_dir().unwrap().join("soundscope/.current_theme");
+        let current_theme = config_dir().unwrap().join("soundscope/current_theme");
         if let Err(err) = fs::write(&current_theme, &name) {
             self.handle_error(format!("Error saving chosen theme: {err}"));
         }
         let mut file = match File::open(path) {
             Ok(file) => file,
             Err(err) => {
-                self.handle_error(format!("Error reading {name}.theme: {err}"));
+                self.handle_error(format!("Error reading {name}: {err}"));
                 return None;
             }
         };
         let mut contents = String::new();
         if let Err(err) = file.read_to_string(&mut contents) {
-            self.handle_error(format!("Error reading {name}.theme: {err}"));
+            self.handle_error(format!("Error reading {name}: {err}"));
             return None;
         }
         if contents == "DEFAULT" {
@@ -2029,82 +2061,66 @@ impl App {
                 if let Err(err) = fs::write(&current_theme, "DEFAULT") {
                     self.handle_error(format!("Error setting theme to DEFAULT: {err}"));
                 }
-                self.handle_error(format!("Error reading {name}.theme: {err}"));
+                self.handle_error(format!("Error reading {name}: {err}"));
                 return None;
             }
         };
         Some(theme)
     }
 
-    /// Called at startup to apply the current theme from a `.current_theme` file if it exists
-    fn apply_current_theme(&mut self, mut path: PathBuf) {
-        // if .config/soundscope does not exist, create it
-        path.push("soundscope");
-        if let Err(_err) = std::fs::create_dir_all(&path) {
-            self.handle_error("Error creating a config path. Make sure it exists.".to_owned());
-        }
-        let current_theme_file = path.join(".current_theme");
-        if current_theme_file.exists() {
-            // read contents of current_theme file
-            // this is the name of the theme {name}.theme or "builtin:theme_name"
-            match std::fs::read_to_string(&current_theme_file) {
-                Ok(theme_file) => {
-                    if theme_file == "DEFAULT" {
+    /// Called at startup to apply the current theme from a `current_theme` file if it exists
+    fn apply_current_theme(&mut self, path: &Path, current_theme_file: &Path) {
+        // read contents of current_theme file
+        // this is the name of the theme {name}.toml or "builtin:theme_name"
+        match fs::read_to_string(current_theme_file) {
+            Ok(theme_file) => {
+                if theme_file == "DEFAULT" {
+                    let mut theme = Theme::default();
+                    theme.apply_global_as_default();
+                    self.set_theme(theme);
+                } else if theme_file.starts_with("builtin:") {
+                    // Load builtin theme
+                    let theme_name = theme_file.strip_prefix("builtin:").unwrap();
+                    if let Some(mut theme) = builtin_themes::get_by_name(theme_name) {
+                        theme.apply_global_as_default();
+                        self.set_theme(theme);
+                    } else {
+                        self.handle_error(format!(
+                            "Builtin theme '{theme_name}' not found. Applying default theme."
+                        ));
                         let mut theme = Theme::default();
                         theme.apply_global_as_default();
                         self.set_theme(theme);
-                    } else if theme_file.starts_with("builtin:") {
-                        // Load builtin theme
-                        let theme_name = theme_file.strip_prefix("builtin:").unwrap();
-                        if let Some(mut theme) = builtin_themes::get_by_name(theme_name) {
-                            theme.apply_global_as_default();
-                            self.set_theme(theme);
-                        } else {
-                            self.handle_error(format!(
-                                "Builtin theme '{theme_name}' not found. Applying default theme."
-                            ));
-                            let mut theme = Theme::default();
-                            theme.apply_global_as_default();
-                            self.set_theme(theme);
-                        }
+                    }
+                } else {
+                    let theme_file = path.join(&theme_file);
+                    let mut theme = if theme_file.exists() {
+                        self.load_theme(&theme_file).unwrap_or_default()
                     } else {
-                        let theme_file = path.join(&theme_file);
-                        let mut theme = if theme_file.exists() {
-                            self.load_theme(&theme_file).unwrap_or_default()
-                        } else {
-                            self.handle_error(format!(
-                                "Theme file {} not found. Applying default theme.",
-                                theme_file.display()
-                            ));
-                            if let Err(err) = fs::write(&current_theme_file, "DEFAULT") {
-                                self.handle_error(format!("Error setting theme to DEFAULT: {err}"));
-                            }
-                            Theme::default()
-                        };
-                        theme.apply_global_as_default();
-                        self.set_theme(theme);
-                    }
-                }
-                Err(err) => {
-                    self.handle_error(format!(
-                        "Error reading .current_theme file {err}. Applying default theme."
-                    ));
-                    if let Err(err) = fs::write(&current_theme_file, "DEFAULT") {
-                        self.handle_error(format!("Error setting theme to DEFAULT: {err}"));
-                    }
-                    let mut theme = Theme::default();
+                        self.handle_error(format!(
+                            "Theme file {} not found. Applying default theme.",
+                            theme_file.display()
+                        ));
+                        if let Err(err) = fs::write(current_theme_file, "DEFAULT") {
+                            self.handle_error(format!("Error setting theme to DEFAULT: {err}"));
+                        }
+                        Theme::default()
+                    };
                     theme.apply_global_as_default();
                     self.set_theme(theme);
                 }
             }
-        } else {
-            File::create(path.join(".current_theme"))
-                .unwrap()
-                .write_all(b"DEFAULT")
-                .unwrap();
-            let mut theme = Theme::default();
-            theme.apply_global_as_default();
-            self.set_theme(theme);
+            Err(err) => {
+                self.handle_error(format!(
+                    "Error reading current_theme file {err}. Applying default theme."
+                ));
+                if let Err(err) = fs::write(current_theme_file, "DEFAULT") {
+                    self.handle_error(format!("Error setting theme to DEFAULT: {err}"));
+                }
+                let mut theme = Theme::default();
+                theme.apply_global_as_default();
+                self.set_theme(theme);
+            }
         }
     }
 


### PR DESCRIPTION
Allow `.toml` extension for theme files to enable editor syntax highlighting. The legacy `.theme` extension remains supported.

Fix configuration directory and state file creation to occur only when the user explicitly switches themes, preventing unnecessary file generation on startup. Rename state file from `.current_theme` to `current_theme`.